### PR TITLE
fix shaCompose on Legacy Mercanet to compose SEAL value with array value in parameter

### DIFF
--- a/src/Legacy/Mercanet.php
+++ b/src/Legacy/Mercanet.php
@@ -126,18 +126,24 @@ class Mercanet
         // compose SHA string
         $shaString = '';
         foreach ($parameters as $key => $value) {
-            if ($key != 'keyVersion') {
+            if ($key !== 'keyVersion') {
                 if (is_array($value)) {
-                    shaCompose($value);
+                    $shaString .= $this->shaCompose($value);
                 } else {
                     $shaString .= $value;
                 }
             }
         }
-        $shaString = str_replace("[", "", $shaString);
-        $shaString = str_replace("]", "", $shaString);
-        $shaString = str_replace("\",\"", "", $shaString);
-        $shaString = str_replace("\"", "", $shaString);
+        $shaString = str_replace(
+            [
+                "[",
+                "]",
+                "\",\"",
+                "\"",
+            ],
+            "",
+            $shaString
+        );
         return $shaString;
     }
 


### PR DESCRIPTION
This fix, add parameter as array in the SEAL composition.

It's necessary to use the multiple payment.