### PR TITLE
New url for test environment

### DIFF
--- a/src/Legacy/Mercanet.php
+++ b/src/Legacy/Mercanet.php
@@ -12,7 +12,7 @@ namespace BitBag\MercanetBnpParibasPlugin\Legacy;
  */
 class Mercanet
 {
-    const TEST = "https://payment-webinit-mercanet.test.sips-atos.com/rs-services/v2/paymentInit";
+    const TEST = "https://payment-webinit-mercanet.test.sips-services.com/rs-services/v2/paymentInit";
     const SIMULATION = "https://payment-webinit.simu.mercanet.bnpparibas.net/rs-services/v2/paymentInit";
     const PRODUCTION = "https://payment-webinit.mercanet.bnpparibas.net/rs-services/v2/paymentInit";
 


### PR DESCRIPTION
I was making a test payment to ensure everything was good but seems the test url has been changed
I asked the mercanet support in order to get the new URL which is now : https://payment-webinit-mercanet.test.sips-services.com/rs-services/v2/paymentInit